### PR TITLE
ENG-3667: Changed the endpoint to extract plugins from component-manager (+ENG-3730 environment variables)

### DIFF
--- a/lib/env-bundler.js
+++ b/lib/env-bundler.js
@@ -480,6 +480,10 @@ const componentResponseProcessor = {
     const plugins = componentsToFetch;
 
     const schema = {
+      'descriptorVersion': {
+        key: 'descriptorVersion',
+        default: () => { return 'v4' }
+      },
       'metadata.name': 'name',
       'spec.image': 'image',
       'spec.dbms': 'dbms',
@@ -716,7 +720,7 @@ const pluginComponentDescriptorProcessor = function(type, location, code, compon
   
   components.forEach(c => c.environmentVariables.forEach(v => {
     if ('valueFrom' in v) {
-      console.warn('WARNING: Extracted plugin has an external secret of config map that needs to be manually exported: ', c.name, v.name);
+      console.warn('WARNING: Extracted plugin\'s variable references a k8s secret or configmap that will not be extracted: ', c.name, v.name);
     }
   }));
 

--- a/lib/env-bundler.js
+++ b/lib/env-bundler.js
@@ -720,7 +720,7 @@ const pluginComponentDescriptorProcessor = function(type, location, code, compon
   
   components.forEach(c => c.environmentVariables.forEach(v => {
     if ('valueFrom' in v) {
-      console.warn('WARNING: Extracted plugin\'s variable references a k8s secret or configmap that will not be extracted: ', c.name, v.name);
+      console.warn(`WARNING: Extracted plugin variable "${c.name}" references a k8s secret or configmap "${v.name}" that will not be extracted`);
     }
   }));
 

--- a/lib/env-bundler.js
+++ b/lib/env-bundler.js
@@ -31,7 +31,7 @@ const ALL_TYPES = [
   'language',
 ];
 
-var coreBaseApi, k8ssvcApi, clientId, clientSecret, apiUrlTable;
+var coreBaseApi, componentManagerApi, clientId, clientSecret, apiUrlTable;
 
 const componentDetailExtractors = {
   page: (components) =>
@@ -487,6 +487,7 @@ const componentResponseProcessor = {
       'spec.ingressPath': 'ingressPath',
       'spec.roles[].code': 'roles[]',
       'spec.permissions': 'permissions',
+      'spec.environmentVariables': 'environmentVariables',
     };
 
     return plugins.map(p => objectMapper(p, schema));
@@ -710,6 +711,18 @@ const defaultComponentDescriptorProcessor = function(type, location, code, compo
     });
 }
 
+const pluginComponentDescriptorProcessor = function(type, location, code, components) {
+  const result = defaultComponentDescriptorProcessor(type, location, code, components);
+  
+  components.forEach(c => c.environmentVariables.forEach(v => {
+    if ('valueFrom' in v) {
+      console.warn('WARNING: Extracted plugin has an external secret of config map that needs to be manually exported: ', c.name, v.name);
+    }
+  }));
+
+  return result;
+}
+
 const assetComponentDescriptorProcessor = function(type, location, code, components) {
   const typePlural = typeToPlural(type);
   const codeExtractor = componentCodeExtractors[type];
@@ -788,7 +801,7 @@ const componentDescriptorProcessors = {
     return assetComponentDescriptorProcessor(type, location, code, components);
   },
   plugin: (type, location, code, components) => {
-    return defaultComponentDescriptorProcessor(type, location, code, components);
+    return pluginComponentDescriptorProcessor(type, location, code, components);
   },
   group: (type, location, code, components) => {
     return groupIntoSingleComponentDescriptorProcessor(type, location, code, components);
@@ -849,13 +862,7 @@ async function getComponents (type, componentsToFetch) {
       headers: { Authorization: `Bearer ${token}` },
     });
 
-    if (type === 'plugin') {
-      componentsToFetch = response.data._embedded &&
-        response.data._embedded.entandoPlugins ||
-        [];
-    } else {
-      componentsToFetch = response.data.payload;
-    }
+    componentsToFetch = response.data.payload;
   }
 
   // Process response and extract any aditional details
@@ -1155,7 +1162,7 @@ async function setupEnvironment (options) {
 
   // Setup env variables
   coreBaseApi = envContent.coreBaseApi;
-  k8ssvcApi = envContent.k8ssvcApi;
+  componentManagerApi = envContent.componentManagerApi || envContent.k8ssvcApi;
   clientId = envContent.clientId;
   clientSecret = envContent.clientSecret;
 
@@ -1178,7 +1185,7 @@ async function setupEnvironment (options) {
     contentModel: `${coreBaseApi}/api/plugins/cms/contentmodels`,
     content: `${coreBaseApi}/api/plugins/cms/contents`,
     asset: `${coreBaseApi}/api/plugins/cms/assets`,
-    plugin: `${k8ssvcApi}/plugins`,
+    plugin: `${componentManagerApi}/plugins`,
     resource: `${coreBaseApi}/api/fileBrowser?protectedFolder=false&currentPath=`,
     resourceDetails: `${coreBaseApi}/api/fileBrowser/file?protectedFolder=false&currentPath={path}`,
   };


### PR DESCRIPTION
- Changed the endpoint to extract plugins from component-manager instead of k8s-service;
- Added plugin environment variables extraction;
- Added a warning when extracting a plugin that has external config/secret maps;